### PR TITLE
Added drag & drop feature

### DIFF
--- a/matrixeater/src/com/matrixeater/src/MainPanel.java
+++ b/matrixeater/src/com/matrixeater/src/MainPanel.java
@@ -10,6 +10,9 @@ import java.awt.Image;
 import java.awt.Insets;
 import java.awt.KeyboardFocusManager;
 import java.awt.Point;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.dnd.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -1659,6 +1662,75 @@ public class MainPanel extends JPanel
 				MainPanel.this.setMouseCoordDisplay(dimension1, dimension2, coord1, coord2);
 			}
 		};
+
+
+		setDropTarget(new DropTarget(this, DnDConstants.ACTION_COPY, new DropTargetListener() {
+			@Override
+			public void dragEnter(DropTargetDragEvent dtde) {
+
+			}
+
+			@Override
+			public void dragOver(DropTargetDragEvent dtde) {
+				try {
+					Transferable transferable = dtde.getTransferable();
+					if (transferable.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
+						List<File> droppedFiles = (List<File>) transferable.getTransferData(DataFlavor.javaFileListFlavor);
+
+						if (!droppedFiles.isEmpty()) {
+							File file = droppedFiles.get(0);
+							String fileName = file.getName().toLowerCase();
+
+							// Limit the allowed file formats
+							if (fileName.endsWith(".blp") || fileName.endsWith(".png") || fileName.endsWith(".mdx")
+									|| fileName.endsWith(".mdl") || fileName.endsWith(".obj")) {
+								dtde.acceptDrag(DnDConstants.ACTION_COPY);
+							} else {
+								dtde.rejectDrag();
+							}
+						}
+					}
+				} catch (Exception e) {
+					ExceptionPopup.display(e);
+					e.printStackTrace();
+				}
+			}
+
+			@Override
+			public void dropActionChanged(DropTargetDragEvent dtde) {
+				int dropAction = dtde.getDropAction();
+				if (dropAction != DnDConstants.ACTION_COPY) {
+					dtde.rejectDrag();
+				}
+			}
+
+			@Override
+			public void dragExit(DropTargetEvent dte) {
+
+			}
+
+			@Override
+			public void drop(DropTargetDropEvent dtde) {
+				try {
+					// Accept the drag as a copy action (this allows file drop)
+					dtde.acceptDrop(DnDConstants.ACTION_COPY);
+
+					// Get the dropped files
+					Transferable transferable = dtde.getTransferable();
+					if (transferable.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
+						List<File> droppedFiles = (List<File>) transferable.getTransferData(DataFlavor.javaFileListFlavor);
+						// Handle the dropped file(s)
+						if (!droppedFiles.isEmpty()) {
+							File droppedFile = droppedFiles.get(0); // Assuming a single file drop
+							openFile(droppedFile);  // Use your existing openFile method to open the dropped file
+						}
+					}
+				} catch (Exception e) {
+					ExceptionPopup.display(e);
+					e.printStackTrace();
+				}
+			}
+		}));
 	}
 
 	private TabWindow createMainLayout() {


### PR DESCRIPTION
I've implemented drag-and-drop functionality to allow users to open files directly into the application. This should improve workflow efficiency, as I personally spent a lot of time navigating through the file explorer. After struggling with this for a while, I decided to spend some time adding this feature.

Though I’m still learning Java GUI development, I believe this solution should work well for basic file opening. I hope it will be helpful to others as well.

- Added drag & drop support for .blp, .png, .mdl, .mdx, and .obj files to open them directly in the GUI.
- Note: The feature may not work correctly on certain parts of the panel.
- Currently tested on Windows only.

PS: thx chatGPT