### PR TITLE
fix: CASC reading failing for some reason (now continues with errors)

### DIFF
--- a/craft3data/src/com/hiveworkshop/blizzard/casc/vfs/PathNode.java
+++ b/craft3data/src/com/hiveworkshop/blizzard/casc/vfs/PathNode.java
@@ -1,6 +1,9 @@
 package com.hiveworkshop.blizzard.casc.vfs;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Represents a path node. Path nodes can either be prefix nodes or file nodes.
@@ -16,12 +19,27 @@ public abstract class PathNode {
 	protected PathNode(final List<byte[]> pathFragments) {
 		this.pathFragments = pathFragments.toArray(new byte[0][]);
 	}
-	
+
 	public int getPathFragmentCount() {
 		return pathFragments.length;
 	}
-	
+
 	public byte[] getFragment(final int index) {
 		return pathFragments[index];
+	}
+
+	@Override
+	public String toString() {
+		return PathNode.toString(this.pathFragments);
+	}
+
+	public static String toString(final byte[][] fragments) {
+		return Stream.of(fragments).map(it -> {
+			try {
+				return new String(it, StandardCharsets.UTF_8);
+			} catch (Exception e) {
+				return "";
+			}
+		}).collect(Collectors.joining("/"));
 	}
 }

--- a/craft3data/src/com/hiveworkshop/blizzard/casc/vfs/VirtualFileSystem.java
+++ b/craft3data/src/com/hiveworkshop/blizzard/casc/vfs/VirtualFileSystem.java
@@ -502,7 +502,13 @@ public final class VirtualFileSystem {
 			if (fileReferenceCount == 1) {
 				// check if nested VFS
 				final Key encodingKey = fileNode.getFileReference(0).getEncodingKey();
-				final TVFSFile tvfsFile = resolveTVFS(encodingKey);
+                TVFSFile tvfsFile;
+                try {
+                    tvfsFile = resolveTVFS(encodingKey);
+                } catch(Exception e){
+                    System.out.println("Failed decoding tvfsFile at " + PathNode.toString(parentPathFragments) + currentNode + ".");
+                    tvfsFile = null;
+                }
 
 				if (tvfsFile != null) {
 					// file is also a folder
@@ -668,11 +674,11 @@ public final class VirtualFileSystem {
 			synchronized (this) {
 				tvfsFile = tvfsCache.get(encodingKey);
 				if (tvfsFile == null) {
-					// decode TVFS from storage
-					final ByteBuffer rootBuffer = fetchStoredBuffer(storageReference);
-					tvfsFile = decoder.loadFile(rootBuffer);
+                    // decode TVFS from storage
+                    final ByteBuffer rootBuffer = fetchStoredBuffer(storageReference);
+                    tvfsFile = decoder.loadFile(rootBuffer);
 
-					tvfsCache.put(storageReference.getEncodingKey(), tvfsFile);
+                    tvfsCache.put(storageReference.getEncodingKey(), tvfsFile);
 				}
 			}
 		}


### PR DESCRIPTION
For some reason, loading CASC fails at _addons/hd2.w3addon/environment.w3mod/_hd.w3mod/_tilesets/g.w3mod.
Reading the size, file flags and key come up with wrong values.
<img width="544" height="146" alt="image" src="https://github.com/user-attachments/assets/0cc3262f-f753-4613-9751-fdbf3693ad21" />

CASCViewer also fails extract this file, so instead of trying to figure out what's wrong with it, I opted for the solution of ignoring files that have the encodingKey mismatch.

(Failed files get logged in the console, for me only that 1 fails)